### PR TITLE
Default providing internal pose to true

### DIFF
--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -56,7 +56,7 @@ public:
             provide_internal_pose = doc.at("provide_internal_pose");
         }
         else{
-            provide_internal_pose = false;
+            provide_internal_pose = true;
         }
 
         // read moving objects


### PR DESCRIPTION
Starting students will be using the default of the simulator before supplying their own poses. So I suggest to make this default in case they forget it in the config.json.