### PR TITLE
Load heightmap from map server

### DIFF
--- a/data/heightmap_metadata.yaml
+++ b/data/heightmap_metadata.yaml
@@ -1,5 +1,5 @@
 image: heightmap.pgm
-resolution: 0.025
+resolution: 0.05
 origin: [0.0, 0.0, -1.570796]
 occupied_thresh: 0.9
 free_thresh: 0.1

--- a/data/heightmap_metadata.yaml
+++ b/data/heightmap_metadata.yaml
@@ -1,5 +1,5 @@
 image: heightmap.pgm
-resolution: 0.05
+resolution: 0.025
 origin: [0.0, 0.0, -1.570796]
 occupied_thresh: 0.9
 free_thresh: 0.1

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -47,7 +47,7 @@ void MapLoader::getMapImage(cv::Mat& imageRef)
 
 void MapLoader::load()
 {
-    ROS_INFO_STEAM("Waiting for map");
+    ROS_INFO_STREAM("Waiting for map");
     while(!initialized)
     {
         cb_map.callAvailable();

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -47,6 +47,7 @@ void MapLoader::getMapImage(cv::Mat& imageRef)
 
 void MapLoader::load()
 {
+    ROS_INFO_STEAM("Waiting for map");
     while(!initialized)
     {
         cb_map.callAvailable();

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -11,6 +11,69 @@
 
 #include <queue>
 
+
+MapLoader::MapLoader()
+{
+    ros::SubscribeOptions map_sub_options = ros::SubscribeOptions::create<nav_msgs::OccupancyGrid>("/map", 1, boost::bind(&MapLoader::mapCallback, this, _1), ros::VoidPtr(), &cb_map);
+    sub_map = nh.subscribe(map_sub_options);
+}
+
+void MapLoader::getMap(nav_msgs::OccupancyGrid& mapRef)
+{
+    if (!initialized)
+    {
+        load();
+    }
+    mapRef = map;
+}
+
+void MapLoader::getMapMetadata(nav_msgs::MapMetaData& metadataRef)
+{
+    if (!initialized)
+    {
+        load();
+    }
+    metadataRef = map.info;
+}
+
+void MapLoader::getMapImage(cv::Mat& imageRef)
+{
+    if (!initialized)
+    {
+        load();
+    }
+    imageRef = mapImage;
+}
+
+void MapLoader::load()
+{
+    while(!initialized)
+    {
+        cb_map.callAvailable();
+    }
+}
+
+void MapLoader::mapCallback(const nav_msgs::OccupancyGrid::ConstPtr& msg)
+{
+    map = *msg;
+    //convert to image
+    mapImage = cv::Mat(map.info.height, map.info.width, CV_8UC1);
+    for (uint row = 0; row < map.info.height; ++row) {
+        for (uint col = 0; col < map.info.width; ++col) {
+            uint index = col + (map.info.height-row) * map.info.width;
+            if (map.data[index] == 0) {
+                mapImage.at<uchar>(row, col) = 255;  // free space
+            } else if (map.data[index] == 100) {
+                mapImage.at<uchar>(row, col) = 0;    // occupied space
+            } else {
+                mapImage.at<uchar>(row, col) = 127;  // door
+            }
+        }
+    }
+    initialized = true;
+    sub_map.shutdown();
+}
+
 // ----------------------------------------------------------------------------------------------------
 
 void findContours(const cv::Mat& image, const geo::Vec2i& p, int d_start, std::vector<geo::Vec2i>& points,
@@ -152,20 +215,25 @@ void findContours(const cv::Mat& image, const geo::Vec2i& p, int d_start, std::v
 
 // ----------------------------------------------------------------------------------------------------
 
+
 geo::ShapePtr createHeightMapShape(const std::string& filename, std::vector<Door>& doors)
 {
-    double resolution = 0.025;
+    cv::Mat image = cv::imread(filename, cv::IMREAD_GRAYSCALE);   // Read the file
+    return createHeightMapShape(image, 0.025, doors);
+}
+
+geo::ShapePtr createHeightMapShape(const cv::Mat& image_tmp, double resolution, std::vector<Door>& doors)
+{
     double origin_z = 0;
     double blockheight = 1.0;
 
-    cv::Mat image_tmp = cv::imread(filename, cv::IMREAD_GRAYSCALE);   // Read the file
     cv::Mat image;
     // Pad Input image with a white border of 1 pixel around, to prevent indexing issues
     cv::copyMakeBorder(image_tmp, image, 1, 1, 1, 1, cv::BORDER_CONSTANT, cv::Scalar(255));
 
     if (!image.data)
     {
-        ROS_ERROR_STREAM("[PICO SIMULATOR] Loading heightmap '" << filename << "' failed.");
+        ROS_ERROR_STREAM("[PICO SIMULATOR] Loading heightmap failed.");
         return geo::ShapePtr();
     }
 

--- a/src/heightmap.h
+++ b/src/heightmap.h
@@ -5,8 +5,42 @@
 
 #include <vector>
 
+#include <ros/subscriber.h>
+#include <ros/callback_queue.h>
+#include <ros/node_handle.h>
+#include <nav_msgs/OccupancyGrid.h>
+
+#include <opencv2/imgproc.hpp>
+
 struct Door;
 
+class MapLoader
+{
+    public:
+    MapLoader();
+
+    void getMap(nav_msgs::OccupancyGrid& mapRef);
+
+    void getMapMetadata(nav_msgs::MapMetaData& metadataRef);
+
+    void getMapImage(cv::Mat& imageRef);
+
+    private:
+    ros::NodeHandle nh;
+
+    void load();
+
+    void mapCallback(const nav_msgs::OccupancyGrid::ConstPtr& msg);
+
+    ros::Subscriber sub_map;
+    ros::CallbackQueue cb_map;
+    bool initialized = false;
+    nav_msgs::OccupancyGrid map;
+    cv::Mat mapImage;
+};
+
 geo::ShapePtr createHeightMapShape(const std::string& filename, std::vector<Door>& doors);
+
+geo::ShapePtr createHeightMapShape(const cv::Mat& image_tmp, double resolution, std::vector<Door>& doors);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,6 +131,9 @@ int main(int argc, char **argv){
     // Add transform from ground truth to internal robot
     if (config.provide_internal_pose.value()) {robot.internalTransform();}
 
+    // Provide the robot with metadata
+    robot.importMetadata(metadata);
+
     // Add door
     for(std::vector<Door>::iterator it = doors.begin(); it != doors.end(); ++it)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,12 @@ int main(int argc, char **argv){
 
     // Load heightmap
     std::vector<Door> doors;
-    geo::ShapePtr heightmap = createHeightMapShape(heightmap_filename, doors);
+    MapLoader loader;
+    cv::Mat mapImage;
+    nav_msgs::MapMetaData metadata;
+    loader.getMapImage(mapImage);
+    loader.getMapMetadata(metadata);
+    geo::ShapePtr heightmap = createHeightMapShape(mapImage, metadata.resolution, doors);
     if (!heightmap)
     {
         std::cout << "[pyro SIMULATOR] Heightmap could not be loaded" << std::endl;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -18,25 +18,26 @@ void Robot::speakCallback(const std_msgs::String::ConstPtr& msg)
     ROS_WARN_STREAM(robot_name << " says: " << "\033[1;31m" << msg->data << "\033[0m\n");
 }
 
-void Robot::mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg)
+void Robot::importMetadata(const nav_msgs::MapMetaData& metadata)
 {
-    mapconfig.mapResolution = msg->resolution;
-    mapconfig.mapOffsetX =  ((msg->height)*msg->resolution)/2;
-    mapconfig.mapOffsetY = -((msg->width)*msg->resolution)/2;
-
-    tf2::Quaternion q(msg->origin.orientation.x, 
-                      msg->origin.orientation.y, 
-                      msg->origin.orientation.z, 
-                      msg->origin.orientation.w);
-
+    tf2::Quaternion q(metadata.origin.orientation.x,
+                      metadata.origin.orientation.y,
+                      metadata.origin.orientation.z,
+                      metadata.origin.orientation.w);
+    
     tf2::Matrix3x3 T(q);
 
     double roll, pitch, yaw;
     T.getRPY(roll, pitch, yaw);
 
     mapconfig.mapOrientation = yaw + M_PI/2;
+
+    mapconfig.mapResolution = metadata.resolution;
+
+    mapconfig.mapOffsetX = (metadata.width * mapconfig.mapResolution / 2) * cos(yaw)-(metadata.height * mapconfig.mapResolution / 2) * sin(yaw) + metadata.origin.position.x;
+    mapconfig.mapOffsetY = (metadata.width * mapconfig.mapResolution / 2) * sin(yaw)+(metadata.height * mapconfig.mapResolution / 2) * cos(yaw) + metadata.origin.position.y;
+
     mapconfig.mapInitialised = true;
-    sub_mapdata.shutdown();
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -64,7 +65,6 @@ Robot::Robot(const std::string &name, Id id, bool disable_speedcap, bool uncerta
     sub_base_ref = nh.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, &Robot::baseReferenceCallback, this);
     sub_open_door = nh.subscribe<std_msgs::Empty>("/" + robot_name + "/open_door", 1, &Robot::openDoorCallback, this);
     sub_speak = nh.subscribe<std_msgs::String>("/" + robot_name + "/text_to_speech/input", 1, &Robot::speakCallback, this);
-    sub_mapdata = nh.subscribe<nav_msgs::MapMetaData>("/map_metadata",1, &Robot::mapCallback, this);
 
 }   
 
@@ -92,11 +92,8 @@ void Robot::pubTransform(const geo::Pose3D &pose, const MapConfig &mapconfig)
     transformStamped.header.stamp = ros::Time::now();
     transformStamped.header.frame_id = "map";
     transformStamped.child_frame_id = "ground_truth/base_link";
-    transformStamped.transform.translation.x =   pose.t.x + cos(mapconfig.mapOrientation) * mapconfig.mapOffsetX 
-                                                          + sin(mapconfig.mapOrientation) * mapconfig.mapOffsetY;
-
-    transformStamped.transform.translation.y =   pose.t.y - sin(mapconfig.mapOrientation) * mapconfig.mapOffsetX
-                                                          + cos(mapconfig.mapOrientation) * mapconfig.mapOffsetY;
+    transformStamped.transform.translation.x =   pose.t.x + mapconfig.mapOffsetX;
+    transformStamped.transform.translation.y =   pose.t.y + mapconfig.mapOffsetY;
 
     transformStamped.transform.translation.z =   pose.t.z + 0.044;
     tf2::Quaternion q;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -87,21 +87,32 @@ void Robot::pubTransform(const geo::Pose3D &pose, const MapConfig &mapconfig)
     pub_joints_ground_truth.publish(jointState);
     pub_joints_internal.publish(jointState);
 
+    // Calculate tf transform
+    tf2::Transform tf_map, tf_robot, tf_total;
+
+    tf_robot.setOrigin(tf2::Vector3(pose.t.x, pose.t.y, pose.t.z + 0.044));
+    tf_robot.setRotation(tf2::Quaternion(0, 0, pose.getYaw()));
+
+    tf_map.setOrigin(tf2::Vector3(mapconfig.mapOffsetX, mapconfig.mapOffsetY, 0));
+    tf_map.setRotation(tf2::Quaternion(0, 0, mapconfig.mapOrientation));
+
+
+
+    tf_total = tf_map * tf_robot;
+
     // Publish tf transform
     geometry_msgs::TransformStamped transformStamped;
     transformStamped.header.stamp = ros::Time::now();
     transformStamped.header.frame_id = "map";
     transformStamped.child_frame_id = "ground_truth/base_link";
-    transformStamped.transform.translation.x =   pose.t.x + mapconfig.mapOffsetX;
-    transformStamped.transform.translation.y =   pose.t.y + mapconfig.mapOffsetY;
+    transformStamped.transform.translation.x =   tf_total.getOrigin().x();
+    transformStamped.transform.translation.y =   tf_total.getOrigin().y();
+    transformStamped.transform.translation.z =   tf_total.getOrigin().z();
 
-    transformStamped.transform.translation.z =   pose.t.z + 0.044;
-    tf2::Quaternion q;
-    q.setRPY(0, 0, pose.getYaw() + mapconfig.mapOrientation);
-    transformStamped.transform.rotation.x = q.x();
-    transformStamped.transform.rotation.y = q.y();
-    transformStamped.transform.rotation.z = q.z();
-    transformStamped.transform.rotation.w = q.w();
+    transformStamped.transform.rotation.x = tf_total.getRotation().x();
+    transformStamped.transform.rotation.y = tf_total.getRotation().y();
+    transformStamped.transform.rotation.z = tf_total.getRotation().z();
+    transformStamped.transform.rotation.w = tf_total.getRotation().w();
     pub_tf2.sendTransform(transformStamped);
 }
 

--- a/src/robot.h
+++ b/src/robot.h
@@ -19,6 +19,7 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 

--- a/src/robot.h
+++ b/src/robot.h
@@ -44,6 +44,8 @@ public:
 
     void internalTransform();
 
+    void importMetadata(const nav_msgs::MapMetaData& metadata);
+
     geo::Pose3D laser_pose;
     std::string robot_name;
     Id robot_id;
@@ -62,7 +64,6 @@ public:
     tf2_ros::StaticTransformBroadcaster pub_tf2static;
     ros::Publisher pub_joints_ground_truth;
     ros::Publisher pub_joints_internal;
-    ros::Subscriber sub_mapdata;
 
 private:
     ros::NodeHandle nh;
@@ -74,7 +75,6 @@ private:
     void baseReferenceCallback(const geometry_msgs::Twist::ConstPtr& msg);
     void openDoorCallback(const std_msgs::Empty::ConstPtr& msg);
     void speakCallback(const std_msgs::String::ConstPtr& msg);
-    void mapCallback(const nav_msgs::MapMetaData::ConstPtr& msg);
 };
 
 

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -193,11 +193,9 @@ visualization_msgs::MarkerArray create_rviz_objectmsg(const World &world, const 
     object.header.frame_id = "map";
     object.header.stamp = ros::Time::now();
     object.action = visualization_msgs::Marker::MODIFY;
-    object.pose.position.x = cos(mapconfig.mapOrientation) * mapconfig.mapOffsetX 
-                           + sin(mapconfig.mapOrientation) * mapconfig.mapOffsetY;
+    object.pose.position.x = mapconfig.mapOffsetX;
 
-    object.pose.position.y = - sin(mapconfig.mapOrientation) * mapconfig.mapOffsetX
-                             + cos(mapconfig.mapOrientation) * mapconfig.mapOffsetY;
+    object.pose.position.y = mapconfig.mapOffsetY;
                              
     object.pose.position.z = 0.01;
     tf2::Quaternion q;


### PR DESCRIPTION
The heightmap is now loaded from the map server instead of from a filename. This heightmap comes with metadata, which is passed to the robot instead of being loaded by the robot itself. Also includes fixes to how the metadata is used to transform the robot position in rviz.